### PR TITLE
Fix: Empty file name on save & calculate portions if no imput

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 def versionMajor = 2
 def versionMinor = 5
-def versionPatch = 2
+def versionPatch = 3
 
 android {
     compileSdk = 35
@@ -53,13 +53,13 @@ dependencies {
     implementation 'androidx.test.ext:junit:1.3.0'
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'com.google.android.material:material:1.12.0'
-    implementation 'com.google.android.gms:play-services-ads:24.5.0'
+    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.gms:play-services-ads:24.6.0'
     implementation 'com.google.android.gms:play-services-location:21.3.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'com.google.firebase:firebase-ads:23.6.0'
     implementation 'com.google.firebase:firebase-analytics:23.0.0'
-    implementation 'com.google.guava:guava:33.4.8-jre'
+    implementation 'com.google.guava:guava:33.5.0-jre'
     implementation 'com.android.billingclient:billing:8.0.0'
     androidTestImplementation 'org.mockito:mockito-android:5.19.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/app/src/main/java/com/aribasadmetlla/pizzadough/MainActivity.java
+++ b/app/src/main/java/com/aribasadmetlla/pizzadough/MainActivity.java
@@ -203,6 +203,9 @@ public class MainActivity extends AppCompatActivity implements SaveFileDialog.Sa
         // Disabling Inputs
         disableInputs();
 
+        // Set default values
+        editWeightPortion.setText(String.valueOf(280)); // standard weight for a single dough ball
+
         /* HYDRATION SEEK BAR */
         // Sets default
         hydrationSeekBar.setProgress(hydration);
@@ -308,12 +311,17 @@ public class MainActivity extends AppCompatActivity implements SaveFileDialog.Sa
 
             @Override
             public void onClick(View v) {
-                //int portions, portion_weight, total_weight;
                 float flour, water, yeast_per, salt_per, oil_per;
                 float yeast, salt, oil;
+                String toastMessage;
 
                 portions = (editPortions.getText().toString().isEmpty()) ? 0 : Integer.parseInt(editPortions.getText().toString());
-                portion_weight = (editWeightPortion.getText().toString().isEmpty()) ? 280 : Integer.parseInt(editWeightPortion.getText().toString());
+                portion_weight = (editWeightPortion.getText().toString().isEmpty()) ? 0 : Integer.parseInt(editWeightPortion.getText().toString());
+                if (portions <= 0 || portion_weight <= 0) {
+                    toastMessage = getString(R.string.toast_portions_warning);
+                    Toast.makeText(MainActivity.this, toastMessage, Toast.LENGTH_SHORT).show();
+                    return;
+                }
 
                 yeast_per = getConvertedValue(yeastSB);
                 salt_per = getConvertedValue(saltSB);
@@ -339,7 +347,7 @@ public class MainActivity extends AppCompatActivity implements SaveFileDialog.Sa
 
                     Log.i(LOG_TAG, "Flour: " + flour + " | Water: " + water + " | Yeast: " + yeast + " | Salt: " + salt + " | Oil: " + oil);
                 } else {
-                    String toastMessage = getString(R.string.toast_hydration_warning);
+                    toastMessage = getString(R.string.toast_hydration_warning);
                     Toast.makeText(MainActivity.this, toastMessage,
                             Toast.LENGTH_LONG).show();
                 }

--- a/app/src/main/java/com/aribasadmetlla/pizzadough/SaveFileDialog.java
+++ b/app/src/main/java/com/aribasadmetlla/pizzadough/SaveFileDialog.java
@@ -36,7 +36,6 @@ public class SaveFileDialog extends AppCompatDialogFragment {
                 })
                 .setPositiveButton(getText(R.string.save), (dialog, which) -> {
                     if (fileNameEditText.getText().toString().trim().isEmpty()) {
-                        listener.saveFile(null);
                         String toastMessage = getString(R.string.toast_file_name_empty);
                         Toast.makeText(requireActivity(), toastMessage, Toast.LENGTH_SHORT).show();
                         return;

--- a/app/src/main/java/com/aribasadmetlla/pizzadough/SaveFileDialog.java
+++ b/app/src/main/java/com/aribasadmetlla/pizzadough/SaveFileDialog.java
@@ -2,7 +2,6 @@ package com.aribasadmetlla.pizzadough;
 
 import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -32,29 +31,23 @@ public class SaveFileDialog extends AppCompatDialogFragment {
 
         builder.setView(view)
                 .setTitle(getText(R.string.save_recipe))
-                .setNegativeButton(getText(R.string.cancel), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-
-                    }
+                .setNegativeButton(getText(R.string.cancel), (dialog, which) -> {
+                    // User cancelled the dialog
                 })
-                .setPositiveButton(getText(R.string.save), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        if (fileNameEditText.getText().toString().trim().isEmpty()) {
-                            listener.saveFile(null);
-                            String toastMessage = getString(R.string.toast_file_name_empty);
-                            Toast.makeText(requireActivity(), toastMessage, Toast.LENGTH_SHORT).show();
-                            return;
-                        }
-                        String fileName = fileNameEditText.getText().toString().trim();
-                        String filePath = requireActivity().getFilesDir() +
-                                "/" +
-                                fileName.trim() +
-                                ".txt";
-                        File file = new File(filePath);
-                        listener.saveFile(file);
+                .setPositiveButton(getText(R.string.save), (dialog, which) -> {
+                    if (fileNameEditText.getText().toString().trim().isEmpty()) {
+                        listener.saveFile(null);
+                        String toastMessage = getString(R.string.toast_file_name_empty);
+                        Toast.makeText(requireActivity(), toastMessage, Toast.LENGTH_SHORT).show();
+                        return;
                     }
+                    String fileName = fileNameEditText.getText().toString().trim();
+                    String filePath = requireActivity().getFilesDir() +
+                            "/" +
+                            fileName.trim() +
+                            ".txt";
+                    File file = new File(filePath);
+                    listener.saveFile(file);
                 });
 
         return builder.create();

--- a/app/src/main/java/com/aribasadmetlla/pizzadough/SaveFileDialog.java
+++ b/app/src/main/java/com/aribasadmetlla/pizzadough/SaveFileDialog.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -40,7 +41,13 @@ public class SaveFileDialog extends AppCompatDialogFragment {
                 .setPositiveButton(getText(R.string.save), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        String fileName = fileNameEditText.getText().toString();
+                        if (fileNameEditText.getText().toString().trim().isEmpty()) {
+                            listener.saveFile(null);
+                            String toastMessage = getString(R.string.toast_file_name_empty);
+                            Toast.makeText(requireActivity(), toastMessage, Toast.LENGTH_SHORT).show();
+                            return;
+                        }
+                        String fileName = fileNameEditText.getText().toString().trim();
                         String filePath = requireActivity().getFilesDir() +
                                 "/" +
                                 fileName.trim() +

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -44,5 +44,6 @@
     <string name="content_description_send">envia</string>
     <string name="content_description_delete">elimina</string>
     <string name="contextual_one_item_selected">1 seleccionat</string>
-    <string name="toast_portions_warning">El numero de pizzes o el pes no poden ser zero</string>
+    <string name="toast_portions_warning">El número de pizzes o el pes no poden ser zero</string>
+    <string name="toast_file_name_empty">El nom del fitxer no pot estar buit</string>
 </resources>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -44,4 +44,5 @@
     <string name="content_description_send">envia</string>
     <string name="content_description_delete">elimina</string>
     <string name="contextual_one_item_selected">1 seleccionat</string>
+    <string name="toast_portions_warning">El numero de pizzes o el pes no poden ser zero</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -45,4 +45,5 @@
     <string name="content_description_delete">eliminar</string>
     <string name="contextual_one_item_selected">1 seleccionado</string>
     <string name="toast_portions_warning">El número de pizzas o el peso no pueden ser cero</string>
+    <string name="toast_file_name_empty">File name can\'t be empty</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -44,4 +44,5 @@
     <string name="content_description_send">enviar</string>
     <string name="content_description_delete">eliminar</string>
     <string name="contextual_one_item_selected">1 seleccionado</string>
+    <string name="toast_portions_warning">El número de pizzas o el peso no pueden ser cero</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -45,5 +45,5 @@
     <string name="content_description_delete">eliminar</string>
     <string name="contextual_one_item_selected">1 seleccionado</string>
     <string name="toast_portions_warning">El número de pizzas o el peso no pueden ser cero</string>
-    <string name="toast_file_name_empty">File name can\'t be empty</string>
+    <string name="toast_file_name_empty">El nombre del archivo no puede estar vacío</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -45,4 +45,5 @@
     <string name="content_description_delete">elimina</string>
     <string name="contextual_one_item_selected">1 selezionato</string>
     <string name="toast_portions_warning">Il número di panetti o il peso non possono essere zero</string>
+    <string name="toast_file_name_empty">Il nome del file non può essere vuoto</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -44,4 +44,5 @@
     <string name="content_description_send">invia</string>
     <string name="content_description_delete">elimina</string>
     <string name="contextual_one_item_selected">1 selezionato</string>
+    <string name="toast_portions_warning">Il número di panetti o il peso non possono essere zero</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,5 +60,5 @@
     <string name="developer_name" translatable="false">Albert Ribas Admetlla</string>
     <string name="developer_website" translatable="false">www.aribasadmetlla.com</string>
     <string name="toast_portions_warning">Number of portions or portion weight can\'t be zero</string>
-    <string name="toast_file_name_empty">El nombre del archivo no puede estar vacío</string>
+    <string name="toast_file_name_empty">File name can\'t be empty</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,4 +60,5 @@
     <string name="developer_name" translatable="false">Albert Ribas Admetlla</string>
     <string name="developer_website" translatable="false">www.aribasadmetlla.com</string>
     <string name="toast_portions_warning">Number of portions or portion weight can\'t be zero</string>
+    <string name="toast_file_name_empty">El nombre del archivo no puede estar vacío</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,4 +59,5 @@
     <string name="version_n" translatable="false">v1.2.3</string>
     <string name="developer_name" translatable="false">Albert Ribas Admetlla</string>
     <string name="developer_website" translatable="false">www.aribasadmetlla.com</string>
+    <string name="toast_portions_warning">Number of portions or portion weight can\'t be zero</string>
 </resources>


### PR DESCRIPTION
This PR fixes two main bugs/issues:
- When user tries to save a recipe with empty name it warns with a toast message.
- When user has not input the weight for the doughbal or number of portions,l it doesn't allow him to click on CALCULATE, and shows a toast message.

Other: 
- Adds needed strings for new toast messages and their translations
- Addresses lint messages like refactoring new classes to lambdas